### PR TITLE
in_http: fix socket fd leak

### DIFF
--- a/plugins/in_http/http_conn.c
+++ b/plugins/in_http/http_conn.c
@@ -185,6 +185,7 @@ int http_conn_del(struct http_conn *conn)
 
     mk_event_del(ctx->evl, &conn->event);
     mk_list_del(&conn->_head);
+    flb_socket_close(conn->fd);
     flb_free(conn->buf_data);
     flb_free(conn);
 


### PR DESCRIPTION
using the official document, testing the example configuration file[ cause CLOSE_WAIT ].
https://docs.fluentbit.io/manual/pipeline/inputs/http

> lsof -i:9880 
> fluent-bi 237991 admin   25u  IPv4 1256237614      0t0  TCP os74gcc52:9880->os74gcc52:48714 (CLOSE_WAIT)


version: Fluent Bit v1.8.0

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N ] Example configuration file for the change
- [N] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
